### PR TITLE
Bundle reveal.js locally

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,7 +30,6 @@ module.exports = function (eleventyConfig) {
     eleventyConfig.addPassthroughCopy("public");
     eleventyConfig.addPassthroughCopy("assets"); // Keep original assets passthrough if needed
 
-    // No need to copy reveal.js assets locally; using CDN links in layout
 
     // Watch our main CSS file for changes
     eleventyConfig.addWatchTarget("src/css/style.css");

--- a/_includes/reveal-layout.njk
+++ b/_includes/reveal-layout.njk
@@ -9,8 +9,8 @@
     <link rel="icon" type="image/png" href="/assets/aigora-icon.png">
     
     <!-- Reveal.js CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reset.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reveal.css">
+    <link rel="stylesheet" href="/assets/reveal.js/dist/reset.css">
+    <link rel="stylesheet" href="/assets/reveal.js/dist/reveal.css">
     
     <!-- Aigora custom styles -->
     <link rel="stylesheet" href="/assets/css/style.css">
@@ -60,13 +60,13 @@
     </div>
 
     <!-- Reveal.js -->
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reveal.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/plugin/notes/notes.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/plugin/markdown/markdown.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/plugin/highlight/highlight.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/plugin/math/math.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/plugin/zoom/zoom.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/plugin/search/search.js"></script>
+    <script src="/assets/reveal.js/dist/reveal.js"></script>
+    <script src="/assets/reveal.js/plugin/notes/notes.js"></script>
+    <script src="/assets/reveal.js/plugin/markdown/markdown.js"></script>
+    <script src="/assets/reveal.js/plugin/highlight/highlight.js"></script>
+    <script src="/assets/reveal.js/plugin/math/math.js"></script>
+    <script src="/assets/reveal.js/plugin/zoom/zoom.js"></script>
+    <script src="/assets/reveal.js/plugin/search/search.js"></script>
     
     <script>
         // Apply saved theme preference

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:css": "npx postcss src/css/style.css -o _site/assets/css/style.css && npx postcss src/css/reveal-aigora.css -o _site/assets/css/reveal-aigora.css",
     "build:11ty": "eleventy",
-    "build": "npm run build:css && npm run build:11ty",
+    "build": "npm run copy:reveal && npm run build:css && npm run build:11ty",
     "start": "npm run build && eleventy --serve",
-    "serve": "eleventy --serve"
+    "serve": "eleventy --serve",
+    "copy:reveal": "node scripts/copy-reveal.js"
   },
   "keywords": [
     "eleventy",

--- a/scripts/copy-reveal.js
+++ b/scripts/copy-reveal.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+function copyDir(src, dest) {
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src)) {
+    const srcPath = path.join(src, entry);
+    const destPath = path.join(dest, entry);
+    if (fs.statSync(srcPath).isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+const projectRoot = path.resolve(__dirname, '..');
+const revealSrc = path.join(projectRoot, 'node_modules', 'reveal.js');
+const revealDest = path.join(projectRoot, 'assets', 'reveal.js');
+
+copyDir(path.join(revealSrc, 'dist'), path.join(revealDest, 'dist'));
+copyDir(path.join(revealSrc, 'plugin'), path.join(revealDest, 'plugin'));
+


### PR DESCRIPTION
## Summary
- copy reveal.js assets from node_modules before build
- serve reveal.js locally instead of CDN

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683a2f101d648324bc67b206f25122e4